### PR TITLE
fix(use-shared-state): action ref made proper for actions func to be same ref

### DIFF
--- a/src/core/create-action-slice.ts
+++ b/src/core/create-action-slice.ts
@@ -59,38 +59,40 @@ export const createActionSlice: CreateActionSliceType = function (
     //#endregion
 
     //#region map action to execute reducerSlice and ioAction
-    allAvailableActionKeys.forEach((actionKey) => {
-      actions[actionKey] = (
-        data: any,
-        inputNewState?: any,
-        inputPrevState?: any
-      ) => {
-        const prevState =
-          inputPrevState ?? (getState?.() as any)[key] ?? initialState
-        // before runIO started run our reducers to reducerSlice states
-        if (reducerActions[actionKey]) reducerActions[actionKey](data)
+    if (actionsRef) {
+      allAvailableActionKeys.forEach((actionKey) => {
+        actions[actionKey] = (
+          data: any,
+          inputNewState?: any,
+          inputPrevState?: any
+        ) => {
+          const prevState =
+            inputPrevState ?? (getState?.() as any)[key] ?? initialState
+          // before runIO started run our reducers to reducerSlice states
+          if (reducerActions[actionKey]) reducerActions[actionKey](data)
 
-        // Async actions will get updated state after reducer work is done
-        // first make async called to make sure we have current state to be used in async action
+          // Async actions will get updated state after reducer work is done
+          // first make async called to make sure we have current state to be used in async action
 
-        if (asyncActions[actionKey]) {
-          const ioActions: any[] = asyncActions[actionKey](
-            data,
-            inputNewState,
-            prevState
-          )
-          // execute IO
-          if (typeof ioRunner === 'function') {
-            try {
-              ioRunner(ioActions)
-            } catch (err) {
-              console.error('error running ioRunner', err)
+          if (asyncActions[actionKey]) {
+            const ioActions: any[] = asyncActions[actionKey](
+              data,
+              inputNewState,
+              prevState
+            )
+            // execute IO
+            if (typeof ioRunner === 'function') {
+              try {
+                ioRunner(ioActions)
+              } catch (err) {
+                console.error('error running ioRunner', err)
+              }
             }
           }
+          return true
         }
-        return true
-      }
-    })
+      })
+    }
     //#endregion
 
     return {

--- a/src/core/create-global-state.ts
+++ b/src/core/create-global-state.ts
@@ -1,4 +1,3 @@
-import {createActionsReferenceFromActionSlice} from './create-actions-reference'
 import {CreateGlobalStateType} from './create-global-state.type'
 
 export const createGlobalState: CreateGlobalStateType = function (
@@ -7,7 +6,7 @@ export const createGlobalState: CreateGlobalStateType = function (
   autoMount = true
 ) {
   let isMounted = !autoMount // for global store(share by multiple molecules) we need way for auto mount
-  let actionsRef = createActionsReferenceFromActionSlice(actionSlice)
+  let actionsRef = undefined // this helps initialise a value which is going to reset in use-global-state
   return {
     key,
     actionSlice,

--- a/src/hooks/use-global-state.ts
+++ b/src/hooks/use-global-state.ts
@@ -1,21 +1,35 @@
-import {useContext, useMemo} from 'react'
+import {useContext, useMemo, useState} from 'react'
 import {shallowEqual} from 'react-redux'
 import {UseReduxStateType} from './use-global-state.type'
 import {useReduxState} from './use-redux-state'
 import {RewireContext} from '../shared/provider'
+import {ActionType} from '../core/create-action-slice-type'
 export const useGlobalState: UseReduxStateType = function (
   globalStore,
   stateSelector = (_: any) => _,
   equalityFn = shallowEqual
 ) {
   const {globalStoreInitMap, setGlobalStoreInitMap} = useContext(RewireContext)
+
+  // actionsRef undefined for first time, so that we get new actions from useReduxState
+  const [actionsRef, setActionsRef] = useState<
+    ActionType<any, any> | undefined
+  >(globalStore.actionsRef)
   const [key, state, actions] = useReduxState(
     globalStore.key,
     globalStore.actionSlice,
     stateSelector,
     equalityFn,
-    globalStore.actionsRef
+    actionsRef
   )
+  useMemo(() => {
+    if (actionsRef !== actions) {
+      // set this globalStore.actionsRef, so that globalState called from different comp, gets same actionsRef
+      globalStore.actionsRef = actions
+      setActionsRef(actions)
+    }
+  }, [actions])
+
   useMemo(() => {
     // global store mount action call
     if (globalStore.autoMount && !globalStoreInitMap[key]) {

--- a/src/hooks/use-shared-state.ts
+++ b/src/hooks/use-shared-state.ts
@@ -1,6 +1,5 @@
-import {useEffect, useMemo} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import {shallowEqual} from 'react-redux'
-import {createActionsReferenceFromActionSlice} from '../core/create-actions-reference'
 import {keyHandler} from '../helper/key-handler'
 import {useReduxState} from './use-redux-state'
 import {UseReduxStateType} from './use-shared-state.type'
@@ -13,16 +12,9 @@ export const useSharedState: UseReduxStateType = function(
 ) {
   const rootKey = keyHandler.getUniqueRoot(compKey)
   const finalKey = keyHandler.concat(rootKey, sharedStore.partialKey)
-  const actionsRef = useMemo(() => {
-    // check if new actions Ref creation is required
-    if (sharedStore.actionsRefsKeyMap[finalKey] === undefined) {
-      // create new actionRef for first mount of specific screen shared store
-      sharedStore.actionsRefsKeyMap[
-        finalKey
-      ] = createActionsReferenceFromActionSlice(sharedStore.actionSlice)
-    }
-    return sharedStore.actionsRefsKeyMap[finalKey]
-  }, [])
+  const [actionsRef, setActionsRef] = useState(
+    sharedStore.actionsRefsKeyMap[finalKey]
+  )
   const [key, state, actions] = useReduxState(
     finalKey,
     sharedStore.actionSlice,
@@ -30,6 +22,13 @@ export const useSharedState: UseReduxStateType = function(
     equalityFn,
     actionsRef
   )
+  useMemo(() => {
+    if (sharedStore.actionsRefsKeyMap[finalKey] !== actions) {
+      sharedStore.actionsRefsKeyMap[finalKey] = actions
+      setActionsRef(actions)
+    }
+  }, [actions])
+
   useMemo(() => {
     if (sharedStore.attachedComponentsCount[key] === undefined)
       sharedStore.attachedComponentsCount[key] = 0


### PR DESCRIPTION
Actions ref passed in all actions.ts file will be same across life cycle of component, specially for shared and global state